### PR TITLE
Bump Nokogiri version to avoid security vulnerabilities

### DIFF
--- a/fastlane-plugin-xml_editor.gemspec
+++ b/fastlane-plugin-xml_editor.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  spec.add_dependency 'plist', '~> 3.3.0'
+  spec.add_dependency 'plist', '~> 3.3'
   spec.add_dependency 'nokogiri', '~> 1.12'
 
   spec.add_development_dependency 'pry'

--- a/fastlane-plugin-xml_editor.gemspec
+++ b/fastlane-plugin-xml_editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   spec.add_dependency 'plist', '~> 3.3.0'
-  spec.add_dependency 'nokogiri', '~> 1.11.0'
+  spec.add_dependency 'nokogiri', '~> 1.12'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/xml_editor/version.rb
+++ b/lib/fastlane/plugin/xml_editor/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module XmlEditor
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
This PR bumps the Nokogiri version so that projects that use this library can avoid [CVE-2021-41098](https://github.com/advisories/GHSA-2rr5-8q37-2w7h).

I have also loosened the dependency version specifier (see [this page](https://docs.ruby-lang.org/en/2.6.0/Gem/Version.html#class-Gem::Version-label-Preventing+Version+Catastrophe-3A) for an explanation of how Rubygems "approximate" version specifiers work) so that any 1.x Nokogiri version is considered to be compatible, since Nokogiri seems to have security vulnerabilities logged against it somewhat regularly.

@ustudio/reviewers Please review