### PR TITLE
[POD-2471] Upgrade Nokogiri to fix dependabot alerts

### DIFF
--- a/fastlane-plugin-xml_editor.gemspec
+++ b/fastlane-plugin-xml_editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   spec.add_dependency 'plist', '~> 3.3'
-  spec.add_dependency 'nokogiri', '~> 1.12'
+  spec.add_dependency 'nokogiri', '~> 1.13'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/xml_editor/version.rb
+++ b/lib/fastlane/plugin/xml_editor/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module XmlEditor
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
This PR bumps Nokogiri to resolve a bunch of dependabot alerts. Since this plugin is being used in the mobile app, I am only upgrading to version of Nokogiri that is compatible with our current version of ruby.

@ustudio/reviewers Please Review.